### PR TITLE
Changes for Amazon Linux 2023

### DIFF
--- a/.ebextensions/00_install_certbot.config
+++ b/.ebextensions/00_install_certbot.config
@@ -1,17 +1,16 @@
 container_commands:
-    00_download_epel:
-        command: "sudo wget -r --no-parent -A 'epel-release-*.rpm' http://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/"
+    00_dnf_install_python3:
+        command: "sudo dnf install python3 augeas-libs"
         ignoreErrors: true
-        test: test ! -d "/etc/letsencrypt/"
-    10_install_epel_release:
-        command: "sudo rpm -Uvh dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-*.rpm"
+    10_python3_venv:
+        command: "sudo python3 -m venv /opt/certbot/"
         ignoreErrors: true
-        test: test ! -d "/etc/letsencrypt/"
-    20_enable_epel:
-        command: "sudo yum-config-manager --enable epel*"
+    20_pip_install_certbot:
+        command: "sudo /opt/certbot/bin/pip install --upgrade pip"
         ignoreErrors: true
-        test: test ! -d "/etc/letsencrypt/"
-    30_install_certbot:
-        command: "sudo yum install -y certbot python2-certbot-apache"
+    30_pip_install_certbot:
+        command: "sudo /opt/certbot/bin/pip install certbot certbot-apache"
         ignoreErrors: true
-        test: test ! -d "/etc/letsencrypt/"
+    40_certbot_run:
+        command: "sudo ln -s /opt/certbot/bin/certbot /usr/bin/certbot"
+        ignoreErrors: true

--- a/.ebextensions/00_install_certbot.config
+++ b/.ebextensions/00_install_certbot.config
@@ -12,5 +12,5 @@ container_commands:
         command: "sudo /opt/certbot/bin/pip install certbot certbot-apache"
         ignoreErrors: true
     40_certbot_run:
-        command: "sudo ln -s /opt/certbot/bin/certbot /usr/bin/certbot"
+        command: "sudo ln -sf /opt/certbot/bin/certbot /usr/bin/certbot"
         ignoreErrors: true

--- a/.ebextensions/00_install_certbot.config
+++ b/.ebextensions/00_install_certbot.config
@@ -1,6 +1,6 @@
 container_commands:
     00_dnf_install_python3:
-        command: "sudo dnf install python3 augeas-libs"
+        command: "sudo dnf install -q -y python3 augeas-libs"
         ignoreErrors: true
     10_python3_venv:
         command: "sudo python3 -m venv /opt/certbot/"

--- a/.platform/hooks/postdeploy/00_get_certificate.sh
+++ b/.platform/hooks/postdeploy/00_get_certificate.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-sudo certbot -n -d polifono.com -d www.polifono.com --apache --agree-tos --email flavio10araujo@gmail.com
+sudo certbot -v -n -d polifono.com -d www.polifono.com --apache --agree-tos --email flavio10araujo@gmail.com


### PR DESCRIPTION
We are currently using the AWS Elastic Beanstalk platform: Tomcat 8.5 with Corretto 8 running on 64bit Amazon Linux 2/4.3.14.

This platform is going to be deprecated in 30/09/2024 according to this [link](https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-retiring.html#platforms-retiring.java).

This PR is to change the Elastic Beanstalk configs to run in the new platform: Tomcat 10 with Corretto 17 running on 64bit Amazon Linux 2023/5.1.1